### PR TITLE
Fixing error 404

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,12 +9,16 @@ plugins:
         - locale: en
           name: English
           build: true
+          docs_dir: docs/en  # Engleski fajlovi se učitavaju iz `docs/en`
         - locale: sh
           name: Srpski
           default: true
           build: true
+          docs_dir: docs/sh  # Srpski fajlovi se učitavaju iz `docs/sh`
+
 theme:
   name: material
+  custom_dir: overrides
   logo: /assets/logo.png
   favicon: assets/favicon.ico
   features:
@@ -49,7 +53,8 @@ theme:
         icon: material/lightbulb-outline
         name: Switch to light mode
 extra_css:
-  - overrides/extra.css     
+  - overrides/extra.css  
+ 
 extra:
   alternate:
     - name: English
@@ -71,6 +76,8 @@ extra:
       link: https://www.instagram.com/bcility/
     - icon: fontawesome/brands/linkedin
       link: https://rs.linkedin.com/company/bcility
+
+use_directory_urls: false
 
 copyright: |
   &copy; 2025 <a href="https://bcility.com/"  target="_blank" rel="noopener">BCILITY</a>

--- a/overrides/404.html
+++ b/overrides/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="refresh" content="0; url=/">
+    <title>Page not found</title>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Prilikom promene jezika sa engleskog na srpski, javljala se greska 404 - not found, zbog toga sto ekstenzija za jezike podrazumeva da se u oba foldera (sh i en) nalaze isti fajlovi, sto kod nas nije slucaj. 